### PR TITLE
Update authentik-worker.xml

### DIFF
--- a/authentik-worker/authentik-worker.xml
+++ b/authentik-worker/authentik-worker.xml
@@ -16,7 +16,7 @@ This is the worker. You will need the Authentik app which is the server. </Overv
   <WebUI/>
   <TemplateURL/>
   <Icon>https://raw.githubusercontent.com/ibracorp/app-logos/main/authentik-worker/authentik_worker.png</Icon>
-  <ExtraParams>--restart unless-stopped</ExtraParams>
+  <ExtraParams>--restart unless-stopped -u root</ExtraParams>
   <PostArgs>worker</PostArgs>
   <CPUset/>
   <DateInstalled>1649705859</DateInstalled>


### PR DESCRIPTION
Authentik worker needs to be set as the root user in order to integrate with docker daemon correctly and deploy outposts (like LDAP.) It also allows the worker to fix the permissions on the mounted folders. This recommendation is documented in the official Authentik docker-compose file.

https://goauthentik.io/docker-compose.yml