### PR TITLE
Update homepage.xml

### DIFF
--- a/homepage/homepage.xml
+++ b/homepage/homepage.xml
@@ -26,4 +26,5 @@
   <Config Name="/app/config" Target="/app/config" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/homepage</Config>
   <Config Name="docker socket" Target="/var/run/docker.sock" Default="" Mode="ro" Description="" Type="Path" Display="always" Required="false" Mask="false">/var/run/docker.sock</Config>
   <Config Name="WebUI" Target="3000" Default="" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
+  <Config Name="HOMEPAGE_ALLOWED_HOSTS" Target="HOMEPAGE_ALLOWED_HOSTS" Default="" Mode="" Description="The value is a comma-separated (no spaces) list of allowed hosts (sometimes with the port) that can host your homepage install. See gethomepage.dev/installation/#homepage_allowed_hosts" Type="Variable" Display="always" Required="true" Mask="false"></Config>
 </Container>


### PR DESCRIPTION
Added `HOMEPAGE_ALLOWED_HOSTS`

REF: https://gethomepage.dev/installation/#homepage_allowed_hosts

"As of v1.0 there is one required environment variable to access homepage via a URL other than `localhost`, `HOMEPAGE_ALLOWED_HOSTS`. The setting helps prevent certain kinds of attacks when retrieving data from the homepage API proxy.

The value is a comma-separated (no spaces) list of allowed hosts (sometimes with the port) that can host your homepage install. See the docker, kubernetes and source installation pages for more information about where / how to set the variable.

`localhost:3000` and `127.0.0.1:3000` are always included, but you can add a domain or IP address to this list to allow that host such as `HOMEPAGE_ALLOWED_HOSTS=gethomepage.dev,192.168.1.2:1234`, etc.

If you are seeing errors about host validation, check the homepage logs and ensure that the host exactly as output in the logs is in the `HOMEPAGE_ALLOWED_HOSTS` list.

This can be disabled by setting `HOMEPAGE_ALLOWED_HOSTS` to * but this is not recommended."