### PR TITLE
Update homepage.xml

### DIFF
--- a/homepage/homepage.xml
+++ b/homepage/homepage.xml
@@ -27,4 +27,6 @@
   <Config Name="docker socket" Target="/var/run/docker.sock" Default="" Mode="ro" Description="" Type="Path" Display="always" Required="false" Mask="false">/var/run/docker.sock</Config>
   <Config Name="WebUI" Target="3000" Default="" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">3000</Config>
   <Config Name="HOMEPAGE_ALLOWED_HOSTS" Target="HOMEPAGE_ALLOWED_HOSTS" Default="" Mode="" Description="The value is a comma-separated (no spaces) list of allowed hosts (sometimes with the port) that can host your homepage install. See gethomepage.dev/installation/#homepage_allowed_hosts" Type="Variable" Display="always" Required="true" Mask="false"></Config>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="" Type="Variable" Display="always" Required="false" Mask="false">100</Config>
 </Container>


### PR DESCRIPTION
By default unRAID runs as 99:100.  For easy editing of files via other containers and expected normal use, containers should run as 99:100.  Upstream project supports PUID/PGID env variables - https://github.com/gethomepage/homepage?tab=readme-ov-file#with-docker.